### PR TITLE
Changed loop through permissions to for-of

### DIFF
--- a/src/calendar.android.ts
+++ b/src/calendar.android.ts
@@ -61,8 +61,7 @@ Calendar._hasPermission = function (perms) {
     return true;
   }
 
-  for (let p in perms) {
-    const permission = perms[p];
+  for (const permission of perms) {
     if (android.content.pm.PackageManager.PERMISSION_GRANTED !== android.support.v4.content.ContextCompat.checkSelfPermission(utils.ad.getApplicationContext(), permission)) {
       return false;
     }


### PR DESCRIPTION
(to prevent properties appended to array (e.g. extension methods) from interfering)

We have "extension-methods" in our project (which means we append methods to Array's prototype, i.e. `Array.prototype.groupBy = function <T, KEY>(keyExtractor: (value: T) => KEY) {/*...*/}`).

Since the changed piece of code uses a very unsafe way of looping through the array, this resulted in an error when calls to the calendar are made after permissions were given by the user.
```
JS: Error in Calendar.findEvents: Error: Cannot convert object to Ljava/lang/String; at index 1
JS: ERROR Error: Cannot convert object to Ljava/lang/String; at index 1
```
The reason for this error was that `permission` has been set to that very extension method `groupBy`. This would get passed to the native API, trying to convert `function` to `java.lang.String`.

Changing the "for-in-index-loop" to a for-of-loop makes the code only loop through the actual elements of the array, not through the properties. This should be the recommended way to loop through arrays.